### PR TITLE
Allow calling '.stop()' inside 'onFinish' event handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ export class GramTGCalls {
             }
 
             if (audio?.listeners?.onFinish) {
-                this.audioStream.on('finish', audio.listeners.onFinish);
+                this.audioStream.once('finish', audio.listeners.onFinish);
             }
 
             this.videoStream = new Stream(video?.readable, {
@@ -86,7 +86,7 @@ export class GramTGCalls {
             }
 
             if (video?.listeners?.onFinish) {
-                this.videoStream.on('finish', video.listeners.onFinish);
+                this.videoStream.once('finish', video.listeners.onFinish);
             }
         } else {
             this.audioStream?.setReadable(audio?.readable);

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,9 +90,15 @@ export class GramTGCalls {
             }
         } else {
             this.audioStream?.setReadable(audio?.readable);
+            if (audio?.listeners?.onFinish) {
+                this.audioStream?.once('finish', audio.listeners.onFinish);
+            }
 
             if (video?.readable) {
                 this.videoStream?.setReadable(video.readable);
+                if (video?.listeners?.onFinish) {
+                    this.videoStream?.once('finish', video.listeners.onFinish);
+                }
             }
             return;
         }


### PR DESCRIPTION
### The Issue

When I want to clean up the connection from `onFinish` event handler, calling the [`.stop()`](https://github.com/tgcallsjs/gram-tgcalls/blob/89a8fcf0a2c5fc3e916f170cd2f017a31eff33b3/src/index.ts#L255) calls the [`.close()`](https://github.com/tgcallsjs/gram-tgcalls/blob/89a8fcf0a2c5fc3e916f170cd2f017a31eff33b3/src/index.ts#L236) method which calls [`.stop()`](https://github.com/tgcallsjs/tgcalls/blob/7a1f7376a65c732b75311d0c0c0cd40071601362/src/stream.ts#L104) of `tgcalls` causing another emit of `finish` . This creates an infinite event loop and the program crashes due to `Maximum callstack size exceed`

### Solution I came up with -

`finish` event should be handled once per stream. So even though it emits some extra finish events, it doesn't turn into an infinite event loop. Also, I am reassigning the handler to the new stream which solves the issue for upcoming streams

---
I do believe this is not an ideal solution but this can be used as a workaround until you came up with proper fix